### PR TITLE
Changes to pass Session Cookie Path Param

### DIFF
--- a/src/main/java/com/hazelcast/web/WebFilter.java
+++ b/src/main/java/com/hazelcast/web/WebFilter.java
@@ -117,6 +117,7 @@ public class WebFilter implements Filter {
 
     private String sessionCookieName = HAZELCAST_SESSION_COOKIE_NAME;
     private String sessionCookieDomain;
+    private String sessionCookiePath;
     private boolean sessionCookieSecure;
     private boolean sessionCookieHttpOnly;
     private boolean stickySession = true;
@@ -217,6 +218,10 @@ public class WebFilter implements Filter {
         if (cookieHttpOnly != null) {
             sessionCookieHttpOnly = Boolean.valueOf(cookieHttpOnly);
         }
+        String cookiePath = getParam("cookie-path");
+        if (cookiePath != null) {
+            sessionCookiePath = cookiePath;
+        }
     }
 
     private void loadProperties() throws ServletException {
@@ -313,7 +318,19 @@ public class WebFilter implements Filter {
 
     private void addSessionCookie(final RequestWrapper req, final String sessionId) {
         final Cookie sessionCookie = new Cookie(sessionCookieName, sessionId);
-        String path = req.getContextPath();
+        
+        //Changes Added to take the session path from Init Parameter if passed
+        //Context Path will be used as Session Path if the Init Param is not passed to keep it backward compatible
+        String path=null;
+        
+        if(null != sessionCookiePath && !sessionCookiePath.isEmpty()){
+        	path = sessionCookiePath;
+        }
+        else
+        {
+        	path = req.getContextPath();
+        }
+        
         if ("".equals(path)) {
             path = "/";
         }


### PR DESCRIPTION
Updated the code to pass Session Cookie Path as a Init Param to the Filter to accommodate scenario where multiple applications deployed on different Applications Servers like Weblogic/Tomcat/JBoss using different Conext Paths can share Session data.

Please refer the issue reported for your reference - https://github.com/hazelcast/hazelcast-wm/issues/17