### PR TITLE
Refactoring on WebFilter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,19 +148,36 @@
                         -Dhazelcast.logging.type=none
                         -Dhazelcast.test.use.network=false
                     </argLine>
-                    <includes>
-                        <include>**/**.java</include>
-                    </includes>
-                    <excludes>
-                        <exclude>**/jsr/**.java</exclude>
-                        <exclude>**/client/**Request.*</exclude>
-                    </excludes>
-                    <groups>com.hazelcast.test.annotation.QuickTest</groups>
-                    <excludedGroups>
-                        com.hazelcast.test.annotation.SlowTest,com.hazelcast.test.annotation.NightlyTest
-                    </excludedGroups>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven.checkstyle.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>checkstyle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <configLocation>${main.basedir}/checkstyle/checkstyle.xml</configLocation>
+                    <suppressionsLocation>${main.basedir}/checkstyle/suppressions.xml</suppressionsLocation>
+                    <headerLocation>${main.basedir}/checkstyle/ClassHeader.txt</headerLocation>
+                    <enableRSS>false</enableRSS>
+                    <linkXRef>true</linkXRef>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
+                    <failOnViolation>true</failOnViolation>
+                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
+                    <enableRulesSummary>true</enableRulesSummary>
+                    <propertyExpansion>main.basedir=${main.basedir}</propertyExpansion>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
@@ -267,23 +284,6 @@
                     </webAppConfig>
                     <stopPort>9966</stopPort>
                     <stopKey>stop</stopKey>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven.surefire.plugin.version}</version>
-                <configuration combine.self="override">
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <runOrder>failedfirst</runOrder>
-                    <argLine>
-                        -Xms128m -Xmx1G -XX:MaxPermSize=128M
-                        -Dhazelcast.phone.home.enabled=false
-                        -Dhazelcast.mancenter.enabled=false
-                        -Dhazelcast.logging.type=none
-                        -Dhazelcast.test.use.network=false
-                    </argLine>
                 </configuration>
             </plugin>
 
@@ -415,39 +415,6 @@
         </dependency>
     </dependencies>
     <profiles>
-        <profile>
-            <id>checkstyle</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-checkstyle-plugin</artifactId>
-                        <version>${maven.checkstyle.plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <phase>validate</phase>
-                                <goals>
-                                    <goal>checkstyle</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <configLocation>${main.basedir}/checkstyle/checkstyle.xml</configLocation>
-                            <suppressionsLocation>${main.basedir}/checkstyle/suppressions.xml</suppressionsLocation>
-                            <headerLocation>${main.basedir}/checkstyle/ClassHeader.txt</headerLocation>
-                            <enableRSS>false</enableRSS>
-                            <linkXRef>true</linkXRef>
-                            <consoleOutput>true</consoleOutput>
-                            <failsOnError>true</failsOnError>
-                            <failOnViolation>true</failOnViolation>
-                            <includeTestSourceDirectory>false</includeTestSourceDirectory>
-                            <enableRulesSummary>true</enableRulesSummary>
-                            <propertyExpansion>main.basedir=${main.basedir}</propertyExpansion>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
             <id>findbugs</id>
             <build>

--- a/src/main/java/com/hazelcast/web/spring/SpringAwareWebFilter.java
+++ b/src/main/java/com/hazelcast/web/spring/SpringAwareWebFilter.java
@@ -52,7 +52,7 @@ public class SpringAwareWebFilter extends WebFilter {
     }
 
     @Override
-    protected HazelcastHttpSession createNewSession(RequestWrapper requestWrapper,
+    protected HazelcastHttpSession createNewSession(HazelcastRequestWrapper requestWrapper,
                                                     String existingSessionId) {
         HazelcastHttpSession session = super.createNewSession(requestWrapper, existingSessionId);
         ApplicationContext appContext =

--- a/src/test/java/com/hazelcast/wm/test/JettyClientFailOverTest.java
+++ b/src/test/java/com/hazelcast/wm/test/JettyClientFailOverTest.java
@@ -16,14 +16,14 @@
 
 package com.hazelcast.wm.test;
 
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(WebTestRunner.class)
 @DelegatedRunWith(Parameterized.class)
-@Category(SlowTest.class)
+@Category(QuickTest.class)
 public class JettyClientFailOverTest extends  WebFilterClientFailOverTests {
 
     public JettyClientFailOverTest(String name, String serverXml1, String serverXml2) {

--- a/src/test/java/com/hazelcast/wm/test/JettyWebFilterTest.java
+++ b/src/test/java/com/hazelcast/wm/test/JettyWebFilterTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.wm.test;
 
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -27,7 +27,7 @@ import java.util.Collection;
 
 @RunWith(WebTestRunner.class)
 @DelegatedRunWith(Parameterized.class)
-@Category(SlowTest.class)
+@Category(QuickTest.class)
 public class JettyWebFilterTest extends WebFilterSlowTests {
 
     @Parameters(name = "Executing: {0}")

--- a/src/test/java/com/hazelcast/wm/test/TomcatClientFailOverTest.java
+++ b/src/test/java/com/hazelcast/wm/test/TomcatClientFailOverTest.java
@@ -16,14 +16,14 @@
 
 package com.hazelcast.wm.test;
 
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(WebTestRunner.class)
 @DelegatedRunWith(Parameterized.class)
-@Category(SlowTest.class)
+@Category(QuickTest.class)
 public class TomcatClientFailOverTest extends WebFilterClientFailOverTests {
 
     public TomcatClientFailOverTest(String name, String serverXml1, String serverXml2) {

--- a/src/test/java/com/hazelcast/wm/test/TomcatWebFilterTest.java
+++ b/src/test/java/com/hazelcast/wm/test/TomcatWebFilterTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.wm.test;
 
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -26,7 +26,7 @@ import java.util.Collection;
 
 @RunWith(WebTestRunner.class)
 @DelegatedRunWith(Parameterized.class)
-@Category(SlowTest.class)
+@Category(QuickTest.class)
 public class TomcatWebFilterTest extends WebFilterSlowTests {
 
     @Parameterized.Parameters(name = "Executing: {0}")

--- a/src/test/java/com/hazelcast/wm/test/WebFilterSessionCleanupTest.java
+++ b/src/test/java/com/hazelcast/wm/test/WebFilterSessionCleanupTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.wm.test;
 
 import com.hazelcast.core.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.http.client.CookieStore;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.junit.Test;
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(WebTestRunner.class)
 @DelegatedRunWith(HazelcastSerialClassRunner.class)
-@Category(SlowTest.class)
+@Category(QuickTest.class)
 public class WebFilterSessionCleanupTest extends AbstractWebFilterTest {
 
     public WebFilterSessionCleanupTest() {

--- a/src/test/java/com/hazelcast/wm/test/spring/SpringAwareWebFilterTest.java
+++ b/src/test/java/com/hazelcast/wm/test/spring/SpringAwareWebFilterTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.wm.test.spring;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.web.spring.SpringAwareWebFilter;
 import com.hazelcast.wm.test.ServletContainer;
 import com.hazelcast.wm.test.TomcatServer;
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(SlowTest.class)
+@Category(QuickTest.class)
 public class SpringAwareWebFilterTest extends SpringAwareWebFilterTestSupport {
 
     @Override


### PR DESCRIPTION
Refactor WebFilter to be more readable
Remove `@SlowTest` annotations from tests since we don't need them for this plugin