### PR TITLE
Generate a new session id when the session is invalidated and created again

### DIFF
--- a/src/main/java/com/hazelcast/web/ClusteredSessionService.java
+++ b/src/main/java/com/hazelcast/web/ClusteredSessionService.java
@@ -244,6 +244,16 @@ public class ClusteredSessionService {
     }
 
     /**
+     * Check if session with sessionId exists on the cluster
+     *
+     * @param sessionId     the session id
+     * @return true if session exists on the cluster
+     */
+    public boolean containsSession(String sessionId) {
+        return clusterMap.containsKey(sessionId);
+    }
+
+    /**
      * Delete session.
      *
      * @param sessionId  sessionId

--- a/src/test/java/com/hazelcast/wm/test/spring/SpringAwareWebFilterTest.java
+++ b/src/test/java/com/hazelcast/wm/test/spring/SpringAwareWebFilterTest.java
@@ -33,6 +33,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -109,4 +110,20 @@ public class SpringAwareWebFilterTest extends SpringAwareWebFilterTestSupport {
         assertEquals("propValue", properties.getProperty("propKey"));
     }
 
+    // https://github.com/hazelcast/hazelcast-wm/issues/6
+    @Test
+    public void testChangeSessionIdAfterLogin() throws Exception {
+        SpringSecuritySession sss = new SpringSecuritySession();
+        request(RequestType.POST_REQUEST,
+                SPRING_SECURITY_LOGIN_URL,
+                serverPort1, sss.cookieStore);
+
+        String hzSessionIdBeforeLogin = sss.getHazelcastSessionId();
+        String jsessionIdBeforeLogin = sss.getSessionId();
+
+        sss = login(sss, false);
+
+        assertNotEquals(jsessionIdBeforeLogin, sss.getSessionId());
+        assertNotEquals(hzSessionIdBeforeLogin, sss.getHazelcastSessionId());
+    }
 }


### PR DESCRIPTION
Don't use existing session id for a new session if it doesn't exist on the cluster
Fixes a bug where the session id doesn't change after invalidating the session and creating it again