### PR TITLE
Fixes #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ To set up Hazelcast Session Clustering:
     <param-name>cookie-path</param-name>
     <param-value>/</param-value>
   </init-param>
+  <init-param>
+    <param-name>use-request-parameter</param-name>
+    <param-value>false</param-value>
+  </init-param>
 </filter>
 <filter-mapping>
   <filter-name>hazelcast-filter</filter-name>
@@ -130,6 +134,7 @@ Following are the descriptions of parameters included in the above XML.
 - `client-config-location`: Location of the client's configuration. It can be specified as a servlet resource, classpath resource or as a URL. Its default value is null.
 - `shutdown-on-destroy`: Specifies whether you want to shut down the Hazelcast instance during the undeployment of your web application. Its default value is true.
 - `deferred-write`: Specifies whether the sessions in each instance will be cached locally. Its default value is false.
+- `use-request-parameter`: Specifies whether a request parameter can be used by the client to send back the session ID value. Its default value is false.
 
 # Using High-Density Memory Store
 
@@ -261,4 +266,21 @@ Here is an example:
 ...
 ```
 
+# Using Request Parameter Instead of Cookie for Sending Back the Session ID
+
+If you have a Servlet that serves REST style `POST` requests and you don't want the clients to use cookies for sending 
+back the session ID, you can enable `use-request-parameter` setting and clients can send back the session ID as a 
+request parameter. You can enable it in your `web.xml` file:
+
+```
+...
+   <init-param>
+            <param-name>use-request-parameter</param-name>
+            <param-value>true</param-value>
+   </init-param>
+...
+```
+
+Note that this causes Hazelcast's `WebFilter` to consume the `ServletRequest#getInputStream` (as it
+needs to examine request parameters) so it will not be available to any servlet that is filtered by this `WebFilter`.
 

--- a/src/main/java/com/hazelcast/web/WebFilter.java
+++ b/src/main/java/com/hazelcast/web/WebFilter.java
@@ -121,6 +121,7 @@ public class WebFilter implements Filter {
     private boolean stickySession = true;
     private boolean shutdownOnDestroy = true;
     private boolean deferredWrite;
+    private boolean useRequestParameter;
     private Properties properties;
     private ClusteredSessionService clusteredSessionService;
 
@@ -196,6 +197,10 @@ public class WebFilter implements Filter {
         String deferredWriteParam = getParam("deferred-write");
         if (deferredWriteParam != null) {
             deferredWrite = Boolean.parseBoolean(deferredWriteParam);
+        }
+        String useRequestParameterParam = getParam("use-request-parameter");
+        if (useRequestParameterParam != null) {
+            useRequestParameter = Boolean.parseBoolean(useRequestParameterParam);
         }
     }
 
@@ -512,8 +517,9 @@ public class WebFilter implements Filter {
                     }
                 }
             }
-            // if hazelcast session id is not found on the cookie, look into request parameters
-            if (hzSessionId == null) {
+            // if hazelcast session id is not found on the cookie and using request parameter is enabled, look into
+            // request parameters
+            if (hzSessionId == null && useRequestParameter) {
                 hzSessionId = getParameter(HAZELCAST_SESSION_COOKIE_NAME);
             }
 

--- a/src/test/java/com/hazelcast/wm/test/TestServlet.java
+++ b/src/test/java/com/hazelcast/wm/test/TestServlet.java
@@ -21,7 +21,9 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
@@ -136,6 +138,25 @@ public class TestServlet extends HttpServlet {
                 session.setAttribute(param, value);
             }
             resp.getWriter().write("null");
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        HttpSession session = req.getSession();
+        session.setAttribute("attr1", "val1");
+
+        if (req.getRequestURI().endsWith("login")) {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(req.getInputStream()));
+            StringBuilder result = new StringBuilder();
+            String line;
+            while((line = reader.readLine()) != null){
+                result.append(line);
+            }
+
+            resp.getWriter().write(result.length() > 0 ? "true" : "false");
+        } else if (req.getRequestURI().endsWith("useRequestParameter")) {
+            resp.getWriter().write(session.getId());
         }
     }
 }

--- a/src/test/webapp/WEB-INF/node2-node.xml
+++ b/src/test/webapp/WEB-INF/node2-node.xml
@@ -55,6 +55,10 @@
             <param-value>20</param-value>
         </init-param>
         <init-param>
+            <param-name>use-request-parameter</param-name>
+            <param-value>true</param-value>
+        </init-param>
+        <init-param>
             <param-name>client-config-location</param-name>
             <param-value>/WEB-INF/hazelcast-client.xml</param-value>
         </init-param>


### PR DESCRIPTION
Add filter init parameter "use-request-parameter" to WebFilter
If enabled, WebFilter checks request parameters to find the existing hazelcast session id