### PR TITLE
Log a warning if a session attribute is not serializable

### DIFF
--- a/src/main/java/com/hazelcast/web/HazelcastHttpSession.java
+++ b/src/main/java/com/hazelcast/web/HazelcastHttpSession.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.web;
 
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.util.EmptyStatement;
 
 import javax.servlet.ServletContext;
@@ -105,6 +106,8 @@ public class HazelcastHttpSession implements HttpSession {
             try {
                 webFilter.getClusteredSessionService().setAttribute(id, name, value);
                 entry.setDirty(false);
+            } catch (HazelcastSerializationException hse) {
+                WebFilter.LOGGER.warning(hse.getMessage());
             } catch (Exception ignored) {
                 EmptyStatement.ignore(ignored);
             }


### PR DESCRIPTION
Not sure whether warning or error is appropriate. 