### PR TITLE
Fix #62

### DIFF
--- a/src/main/java/com/hazelcast/web/HazelcastHttpSession.java
+++ b/src/main/java/com/hazelcast/web/HazelcastHttpSession.java
@@ -113,7 +113,7 @@ public class HazelcastHttpSession implements HttpSession {
         if (cacheEntry == null || cacheEntry.isReload()) {
             try {
                 value = webFilter.getClusteredSessionService().getAttribute(id, name);
-                cacheEntry = new LocalCacheEntry(false, value);
+                cacheEntry = new LocalCacheEntry(transientAttributes.contains(name), value);
                 cacheEntry.setReload(false);
                 localCache.put(name, cacheEntry);
             } catch (Exception e) {

--- a/src/test/java/com/hazelcast/wm/test/TestServlet.java
+++ b/src/test/java/com/hazelcast/wm/test/TestServlet.java
@@ -109,6 +109,12 @@ public class TestServlet extends HttpServlet {
             session.setAttribute("key", "value");
             Object value = session.getAttribute("key");
             resp.getWriter().write(value == null ? "null" : value.toString());
+        } else if (req.getRequestURI().endsWith("writeTransient")) {
+            session.setAttribute("transient1", "value");
+            resp.getWriter().write("true");
+        } else if (req.getRequestURI().endsWith("readTransient")) {
+            Object value = session.getAttribute("transient1");
+            resp.getWriter().write(value == null ? "null" : value.toString());
         } else if (req.getRequestURI().endsWith("reload")) {
             session.invalidate();
             session = req.getSession();

--- a/src/test/java/com/hazelcast/wm/test/TransientAttributeTest.java
+++ b/src/test/java/com/hazelcast/wm/test/TransientAttributeTest.java
@@ -1,0 +1,45 @@
+package com.hazelcast.wm.test;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.apache.http.client.CookieStore;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class TransientAttributeTest extends AbstractWebFilterTest {
+
+    public TransientAttributeTest() {
+        super("node1-node-deferred.xml", "node2-node-deferred.xml");
+    }
+
+    @Test
+    public void testExcludeTransientAttributesFromCluster() throws Exception {
+        CookieStore cookieStore = new BasicCookieStore();
+        assertEquals("true", executeRequest("write", serverPort1, cookieStore));
+        assertEquals("value", executeRequest("read", serverPort2, cookieStore));
+        assertEquals("true", executeRequest("writeTransient", serverPort1, cookieStore));
+        assertEquals("null", executeRequest("readTransient", serverPort2, cookieStore));
+    }
+
+    @Test
+    public void test_issue_62() throws Exception {
+        // Reproducer case for the issue#62.
+        CookieStore cookieStore = new BasicCookieStore();
+        assertEquals("null", executeRequest("readTransient", serverPort1, cookieStore));
+        assertEquals("true", executeRequest("writeTransient", serverPort1, cookieStore));
+        assertEquals("value", executeRequest("readTransient", serverPort1, cookieStore));
+        assertEquals("null", executeRequest("readTransient", serverPort2, cookieStore));
+    }
+
+    @Override
+    protected ServletContainer getServletContainer(int port, String sourceDir, String serverXml) throws Exception {
+        return new JettyServer(port, sourceDir, serverXml);
+    }
+
+}

--- a/src/test/webapp/WEB-INF/node1-node-deferred.xml
+++ b/src/test/webapp/WEB-INF/node1-node-deferred.xml
@@ -47,6 +47,10 @@
             <param-value>true</param-value>
         </init-param>
         <init-param>
+            <param-name>transient-attributes</param-name>
+            <param-value>transient1</param-value>
+        </init-param>
+        <init-param>
             <param-name>session-ttl-seconds</param-name>
            <param-value>20</param-value>
         </init-param>

--- a/src/test/webapp/WEB-INF/node2-node-deferred.xml
+++ b/src/test/webapp/WEB-INF/node2-node-deferred.xml
@@ -47,6 +47,10 @@
             <param-value>true</param-value>
         </init-param>
         <init-param>
+            <param-name>transient-attributes</param-name>
+            <param-value>transient1</param-value>
+        </init-param>
+        <init-param>
             <param-name>session-ttl-seconds</param-name>
             <param-value>20</param-value>
         </init-param>


### PR DESCRIPTION
The related issue is #62.

When `deferred-write` is enabled, the problem occurs in the following scenario:

1. `HazelcastHttpSession#getAttribute(some_attr)` creates a local cache entry with null value. This entry is marked as `non-transient` regardless of it is transient entry or not.
https://github.com/hazelcast/hazelcast-wm/blob/c25e35ac06fe18f43323782238005b9944f4ed53/src/main/java/com/hazelcast/web/HazelcastHttpSession.java#L116
2. `HazelcastHttpSession#setAttribute(some_attr)` marks this entry as `dirty` and at the end of the request, `HazelcastHttpSession#sessionDeferredWrite` method writes this attribute to distributed map since being `dirty && !transient`

This is not the case when `deferred-write = false`.

If `deferred-write` is disabled, the following check prevents the entry to be stored in the distributed map since `transient` flag is properly set in the method:
https://github.com/hazelcast/hazelcast-wm/blob/c25e35ac06fe18f43323782238005b9944f4ed53/src/main/java/com/hazelcast/web/HazelcastHttpSession.java#L97
