### PR TITLE
Fix #67

### DIFF
--- a/src/main/java/com/hazelcast/web/WebFilterConfig.java
+++ b/src/main/java/com/hazelcast/web/WebFilterConfig.java
@@ -37,29 +37,134 @@ import java.util.StringTokenizer;
  * Contains all configuration parameters for Hazelcast session replication
  */
 public final class WebFilterConfig {
+    /**
+     * <p>Configuration key: <code>client-config-location</code></p>
+     * Location of the client's configuration. It can be specified as a servlet resource, classpath resource or as a URL.
+     * Its default value is null.
+     */
+    public static final String CLIENT_CONFIG_LOCATION = "client-config-location";
+
+    /**
+     * <p>Configuration key: <code>session-ttl-seconds</code></p>
+     * Time-to-live value (in seconds) of the distributed map storing your web session objects.
+     * It can be any integer between 0 and {@link java.lang.Integer#MAX_VALUE}.
+     * Its default value is 1800, which is 30 minutes.
+     */
+    public static final String SESSION_TTL_SECONDS = "session-ttl-seconds";
+
+    /**
+     * <p>Configuration key: <code>use-client</code></p>
+     * Specifies whether you want to connect to an existing cluster as a client.
+     * Its default value is false.
+     */
+    public static final String USE_CLIENT = "use-client";
+
+    /**
+     * <p>Configuration key: <code>instance-name</code></p>
+     * Name of an existing Hazelcast instance, if you want to use it.
+     * Its default value is null.
+     * If you do not have an instance, then you should create one.
+     */
+    public static final String INSTANCE_NAME = "instance-name";
+
+    /**
+     * <p>Configuration key: <code>map-name</code></p>
+     * Name of the distributed map storing your web session objects.
+     */
+    public static final String MAP_NAME = "map-name";
+
+    /**
+     * <p>Configuration key: <code>sticky-session</code></p>
+     * If set to true, all requests of a session are routed to the member where the session is first created.
+     * If set to false, when a session is updated on a member, entry for this session on all members is invalidated.
+     * You have to know how your load balancer is configured before setting this parameter.
+     * Its default value is true.
+     */
+    public static final String STICKY_SESSION = "sticky-session";
+
+    /**
+     * <p>Configuration key: <code>config-location</code></p>
+     * Location of Hazelcast configuration. It can be specified as a servlet resource, classpath resource or as a URL.
+     * Its default value is hazelcast-default.xml or hazelcast.xml in the classpath.
+     */
+    public static final String CONFIG_LOCATION = "config-location";
+
+    /**
+     * <p>Configuration key: <code>shutdown-on-destroy</code></p>
+     * Specifies whether you want to shut down the Hazelcast instance during the undeployment of your web application.
+     * Its default value is true.
+     */
+    public static final String SHUTDOWN_ON_DESTROY = "shutdown-on-destroy";
+
+    /**
+     * <p>Configuration key: <code>deferred-write</code></p>
+     * Specifies whether the sessions in each instance will be cached locally. Its default value is false.
+     */
+    public static final String DEFERRED_WRITE = "deferred-write";
+
+    /**
+     * <p>Configuration key: <code>use-request-parameter</code></p>
+     * Specifies whether a request parameter can be used by the client to send back the session ID value.
+     * Its default value is false.
+     */
+    public static final String USE_REQUEST_PARAMETER = "use-request-parameter";
+
+    /**
+     * <p>Configuration key: <code>transient-attributes</code></p>
+     * If you have some attributes that you do not want to be distributed, you can mark those attributes as transient.
+     * Transient attributes are kept in the server and when the server is shutdown, you lose the attribute values.
+     * Values can be defined comma separated. Its default value in null
+     */
+    public static final String TRANSIENT_ATTRIBUTES = "transient-attributes";
+
+    /**
+     * <p>Configuration key: <code>keep-remote-active</code></p>
+     * If set to true,
+     * it's guaranteed that whenever a session is used the idle-time of this session on the distributed map is reset.
+     * Note that this is useless when non-sticky sessions are used or max-idle-second is not set for the cluster map.
+     * Its default value is false.
+     */
+    public static final String KEEP_REMOTE_ACTIVE = "keep-remote-active";
+
+    /**
+     * <p>Configuration key: <code>cookie-name</code></p>
+     * Name of the session ID cookie.
+     */
+    public static final String COOKIE_NAME = "cookie-name";
+
+    /**
+     * <p>Configuration key: <code>cookie-domain</code></p>
+     * Domain of the session ID cookie. Its default value is based on the incoming request.
+     */
+    public static final String COOKIE_DOMAIN = "cookie-domain";
+
+    /**
+     * <p>Configuration key: <code>cookie-secure</code></p>
+     * Specifies whether the cookie only be sent using a secure protocol. Its default value is false.
+     */
+    public static final String COOKIE_SECURE = "cookie-secure";
+
+    /**
+     * <p>Configuration key: <code>cookie-http-only</code></p>
+     * Specifies whether the attribute HttpOnly can be set on cookie. Its default value is false.
+     */
+    public static final String COOKIE_HTTP_ONLY = "cookie-http-only";
+
+    /**
+     * <p>Configuration key: <code>cookie-path</code></p>
+     * Path of the session ID cookie. Its default value is based on the context path of the incoming request.
+     */
+    public static final String COOKIE_PATH = "cookie-path";
+
+    /**
+     * <p>Configuration key: <code>cookie-max-age</code></p>
+     * Specifies the maximum age of the cookie in seconds.
+     * Its default value is -1, meaning the cookie is not stored persistently and will be deleted when the browser exits.
+     */
+    public static final String COOKIE_MAX_AGE = "cookie-max-age";
+
     private static final ILogger LOGGER = Logger.getLogger(WebFilterConfig.class);
-
     private static final int SESSION_TTL_DEFAULT_SECONDS = 1800;
-
-    private static final String CLIENT_CONFIG_LOCATION = "client-config-location";
-    private static final String SESSION_TTL_CONFIG = "session-ttl-seconds";
-    private static final String USE_CLIENT = "use-client";
-    private static final String INSTANCE_NAME = "instance-name";
-    private static final String MAP_NAME = "map-name";
-    private static final String STICKY_SESSION_CONFIG = "sticky-session";
-    private static final String CONFIG_LOCATION = "config-location";
-    private static final String SHUTDOWN_ON_DESTROY = "shutdown-on-destroy";
-    private static final String DEFERRED_WRITE = "deferred-write";
-    private static final String USE_REQUEST_PARAMETER = "use-request-parameter";
-    private static final String TRANSIENT_ATTRIBUTES = "transient-attributes";
-    private static final String KEEP_REMOTE_ACTIVE = "keep-remote-active";
-
-    private static final String COOKIE_NAME = "cookie-name";
-    private static final String COOKIE_DOMAIN = "cookie-domain";
-    private static final String COOKIE_SECURE = "cookie-secure";
-    private static final String COOKIE_HTTP_ONLY = "cookie-http-only";
-    private static final String COOKIE_PATH = "cookie-path";
-    private static final String COOKIE_MAX_AGE = "cookie-max-age";
 
     private boolean useClient;
     private URL configUrl;
@@ -91,7 +196,7 @@ public final class WebFilterConfig {
         String clientConfigLocation = getString(filterConfig, properties, CLIENT_CONFIG_LOCATION, null);
 
         // P2P mode parameters
-        int sessionTtlSeconds = getInt(filterConfig, properties, SESSION_TTL_CONFIG, SESSION_TTL_DEFAULT_SECONDS);
+        int sessionTtlSeconds = getInt(filterConfig, properties, SESSION_TTL_SECONDS, SESSION_TTL_DEFAULT_SECONDS);
         String configLocation = getString(filterConfig, properties, CONFIG_LOCATION, null);
 
         URL configUrl = validateAndGetConfigUrl(filterConfig.getServletContext(), useClient, configLocation,
@@ -101,7 +206,7 @@ public final class WebFilterConfig {
         String instanceName = getString(filterConfig, properties, INSTANCE_NAME, null);
         String mapName = getString(filterConfig, properties, MAP_NAME,
                 "_web_" + filterConfig.getServletContext().getServletContextName());
-        boolean stickySession = getBoolean(filterConfig, properties, STICKY_SESSION_CONFIG, true);
+        boolean stickySession = getBoolean(filterConfig, properties, STICKY_SESSION, true);
         boolean shutdownOnDestroy = getBoolean(filterConfig, properties, SHUTDOWN_ON_DESTROY, true);
         boolean deferredWrite = getBoolean(filterConfig, properties, DEFERRED_WRITE, false);
         boolean useRequestParameter = getBoolean(filterConfig, properties, USE_REQUEST_PARAMETER, false);
@@ -286,7 +391,7 @@ public final class WebFilterConfig {
 
     private static void validateHazelcastConfigParameters(FilterConfig filterConfig, Properties properties, boolean useClient) {
         if (paramExists(filterConfig, properties, INSTANCE_NAME)) {
-            List<String> wrongParams = parametersExist(filterConfig, properties, SESSION_TTL_CONFIG,
+            List<String> wrongParams = parametersExist(filterConfig, properties, SESSION_TTL_SECONDS,
                     CONFIG_LOCATION, CLIENT_CONFIG_LOCATION);
 
             if (!wrongParams.isEmpty()) {
@@ -308,7 +413,7 @@ public final class WebFilterConfig {
         }
 
         if (useClient) {
-            List<String> wrongParams = parametersExist(filterConfig, properties, SESSION_TTL_CONFIG, CONFIG_LOCATION);
+            List<String> wrongParams = parametersExist(filterConfig, properties, SESSION_TTL_SECONDS, CONFIG_LOCATION);
             if (!wrongParams.isEmpty()) {
                 StringBuilder errorMsgBuilder = new StringBuilder("The following parameters cannot be used when "
                         + USE_CLIENT + " is set to 'true': [");

--- a/src/test/java/com/hazelcast/wm/test/WebFilterConfigTest.java
+++ b/src/test/java/com/hazelcast/wm/test/WebFilterConfigTest.java
@@ -24,12 +24,12 @@ public class WebFilterConfigTest {
     public void testInstanceName_withConfigLocation() throws Exception {
         expectedException.expect(InvalidConfigurationException.class);
         expectedException.expectMessage(
-                allOf(containsString("session-ttl-seconds"), containsString("config-location")));
+                allOf(containsString(WebFilterConfig.SESSION_TTL_SECONDS), containsString(WebFilterConfig.CONFIG_LOCATION)));
 
         Properties properties = new Properties();
-        properties.setProperty("instance-name", "instance-1");
-        properties.setProperty("session-ttl-seconds", "20");
-        properties.setProperty("config-location", "some.xml");
+        properties.setProperty(WebFilterConfig.INSTANCE_NAME, "instance-1");
+        properties.setProperty(WebFilterConfig.SESSION_TTL_SECONDS, "20");
+        properties.setProperty(WebFilterConfig.CONFIG_LOCATION, "some.xml");
 
         WebFilterConfig.create(emptyFilterConfig, properties);
     }
@@ -37,8 +37,8 @@ public class WebFilterConfigTest {
     @Test
     public void testInstanceName_withoutConfigLocation() throws Exception {
         Properties properties = new Properties();
-        properties.setProperty("instance-name", "instance-1");
-        properties.setProperty("map-name", "map-1");
+        properties.setProperty(WebFilterConfig.INSTANCE_NAME, "instance-1");
+        properties.setProperty(WebFilterConfig.MAP_NAME, "map-1");
 
         WebFilterConfig.create(emptyFilterConfig, properties);
     }
@@ -46,8 +46,8 @@ public class WebFilterConfigTest {
     @Test
     public void testUseClient_withClientConfigLocation() throws Exception {
         Properties properties = new Properties();
-        properties.setProperty("use-client", "true");
-        properties.setProperty("client-config-location", "some.xml");
+        properties.setProperty(WebFilterConfig.USE_CLIENT, "true");
+        properties.setProperty(WebFilterConfig.CLIENT_CONFIG_LOCATION, "some.xml");
 
         WebFilterConfig.create(emptyFilterConfig, properties);
     }
@@ -55,11 +55,11 @@ public class WebFilterConfigTest {
     @Test
     public void testUseClient_withConfigLocation() throws Exception {
         expectedException.expect(InvalidConfigurationException.class);
-        expectedException.expectMessage(containsString("config-location"));
+        expectedException.expectMessage(containsString(WebFilterConfig.CONFIG_LOCATION));
 
         Properties properties = new Properties();
-        properties.setProperty("use-client", "true");
-        properties.setProperty("config-location", "some.xml");
+        properties.setProperty(WebFilterConfig.USE_CLIENT, "true");
+        properties.setProperty(WebFilterConfig.CONFIG_LOCATION, "some.xml");
 
         WebFilterConfig.create(emptyFilterConfig, properties);
     }
@@ -67,10 +67,10 @@ public class WebFilterConfigTest {
     @Test
     public void bothServletFilterConfigAndPropertiesAreUsed() throws Exception {
         Properties properties = new Properties();
-        properties.setProperty("cookie-name", "customcookiename");
+        properties.setProperty(WebFilterConfig.COOKIE_NAME, "customcookiename");
 
         MapBasedFilterConfig servletFilterConfig = new MapBasedFilterConfig();
-        servletFilterConfig.setParameter("use-client", "true");
+        servletFilterConfig.setParameter(WebFilterConfig.USE_CLIENT, "true");
 
         WebFilterConfig webFilterConfig = WebFilterConfig.create(servletFilterConfig, properties);
         Assert.assertEquals(true, webFilterConfig.isUseClient());
@@ -80,10 +80,10 @@ public class WebFilterConfigTest {
     @Test
     public void propertiesOverrideServletFilterConfiguration() throws Exception {
         Properties properties = new Properties();
-        properties.setProperty("cookie-name", "cookie1");
+        properties.setProperty(WebFilterConfig.COOKIE_NAME, "cookie1");
 
         MapBasedFilterConfig servletFilterConfig = new MapBasedFilterConfig();
-        servletFilterConfig.setParameter("cookie-name", "cookie2");
+        servletFilterConfig.setParameter(WebFilterConfig.COOKIE_NAME, "cookie2");
 
         WebFilterConfig webFilterConfig = WebFilterConfig.create(servletFilterConfig, properties);
         Assert.assertEquals("cookie1", webFilterConfig.getCookieName());


### PR DESCRIPTION
The related issue is #67 

Make property labels public in WebFilterConfig.java which is useful when creating WebFilter programmatically to make it less error-prone.
Renamed STICKY_SESSION_CONFIG to STICKY_SESSION, SESSION_TTL_CONFIG to SESSION_TTL_SECONDS (previously private) to follow the same naming conventions with other variables. 

Added javadocs for public variables & updated tests