### PR TITLE
Bump Hazelcast version to 4.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <name>hazelcast-wm</name>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-wm</artifactId>
-    <version>4.2-SNAPSHOT</version>
+    <version>4.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>Hazelcast In-Memory DataGrid Web Module Plugin</description>
     <url>http://www.hazelcast.com/</url>
@@ -31,7 +31,7 @@
         <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
 
-        <hazelcast.version>4.0</hazelcast.version>
+        <hazelcast.version>4.1</hazelcast.version>
 
         <log4j.version>1.2.12</log4j.version>
         <junit.version>4.12</junit.version>

--- a/src/test/java/com/hazelcast/wm/test/WebFilterBasicTest.java
+++ b/src/test/java/com/hazelcast/wm/test/WebFilterBasicTest.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import java.util.Collections;
 import java.util.HashMap;
 
+import static com.hazelcast.test.Accessors.getNode;
 import static com.hazelcast.wm.test.AbstractWebFilterTest.RequestType.POST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;

--- a/src/test/java/com/hazelcast/wm/test/WebFilterSlowTests.java
+++ b/src/test/java/com/hazelcast/wm/test/WebFilterSlowTests.java
@@ -8,6 +8,7 @@ import org.apache.http.client.CookieStore;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.junit.Test;
 
+import static com.hazelcast.test.Accessors.getNode;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
Bumps Hazelcast version on master to get rid of 4.1-compatibility branch maintenance. CI will now build against the master branch with the master profile (HZ 4.2-snapshot).