### PR TITLE
Fixed getting Boolean values in properties 

### DIFF
--- a/src/main/java/com/hazelcast/web/WebFilterConfig.java
+++ b/src/main/java/com/hazelcast/web/WebFilterConfig.java
@@ -368,7 +368,8 @@ public final class WebFilterConfig {
 
     private static String getValue(FilterConfig filterConfig, Properties properties, String paramName) {
         if (properties != null && properties.containsKey(paramName)) {
-            return properties.getProperty(paramName);
+            Object property = properties.get(paramName);
+            return property.toString();
         } else {
             return filterConfig.getInitParameter(paramName);
         }

--- a/src/main/java/com/hazelcast/web/WebFilterConfig.java
+++ b/src/main/java/com/hazelcast/web/WebFilterConfig.java
@@ -369,10 +369,11 @@ public final class WebFilterConfig {
     private static String getValue(FilterConfig filterConfig, Properties properties, String paramName) {
         if (properties != null && properties.containsKey(paramName)) {
             Object property = properties.get(paramName);
-            return property == null ? filterConfig.getInitParameter(paramName) : property.toString();
-        } else {
-            return filterConfig.getInitParameter(paramName);
+            if (property != null) {
+                return property.toString();
+            }
         }
+        return filterConfig.getInitParameter(paramName);
     }
 
     private static URL validateAndGetConfigUrl(ServletContext ctx, boolean useClient, String configLocation,

--- a/src/main/java/com/hazelcast/web/WebFilterConfig.java
+++ b/src/main/java/com/hazelcast/web/WebFilterConfig.java
@@ -369,7 +369,7 @@ public final class WebFilterConfig {
     private static String getValue(FilterConfig filterConfig, Properties properties, String paramName) {
         if (properties != null && properties.containsKey(paramName)) {
             Object property = properties.get(paramName);
-            return property.toString();
+            return property == null ? filterConfig.getInitParameter(paramName) : property.toString();
         } else {
             return filterConfig.getInitParameter(paramName);
         }

--- a/src/test/java/com/hazelcast/wm/test/WebFilterConfigTest.java
+++ b/src/test/java/com/hazelcast/wm/test/WebFilterConfigTest.java
@@ -88,4 +88,12 @@ public class WebFilterConfigTest {
         WebFilterConfig webFilterConfig = WebFilterConfig.create(servletFilterConfig, properties);
         Assert.assertEquals("cookie1", webFilterConfig.getCookieName());
     }
+
+    @Test
+    public void testBooleanConfigValue() {
+        Properties properties = new Properties();
+        properties.put(WebFilterConfig.COOKIE_HTTP_ONLY, true);
+        WebFilterConfig config = WebFilterConfig.create(emptyFilterConfig, properties);
+        Assert.assertEquals(true, config.isCookieHttpOnly());
+    }
 }

--- a/src/test/java/com/hazelcast/wm/test/WebFilterConfigTest.java
+++ b/src/test/java/com/hazelcast/wm/test/WebFilterConfigTest.java
@@ -90,10 +90,12 @@ public class WebFilterConfigTest {
     }
 
     @Test
-    public void testBooleanConfigValue() {
+    public void testNonStringConfigValues() {
         Properties properties = new Properties();
         properties.put(WebFilterConfig.COOKIE_HTTP_ONLY, true);
+        properties.put(WebFilterConfig.COOKIE_MAX_AGE, 160);
         WebFilterConfig config = WebFilterConfig.create(emptyFilterConfig, properties);
         Assert.assertEquals(true, config.isCookieHttpOnly());
+        Assert.assertEquals(160, config.getCookieMaxAge());
     }
 }


### PR DESCRIPTION
Method getValue try to get a property with a string value (getProperty()). 
When you try to get a Boolean property, this method return a null (because it just can get String values) 
and that's the reason the app put the default value to that property.

I fixed it using the get() method instead getProperty(). get() return an Object and after that I cast it to the type of value I need (in this case Boolean).

Check List:

Fixes #95 
Unit tests : YES