### PR TITLE
Add automated release workflow files 

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,0 +1,55 @@
+name: Deploy Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to be released, e.g. v1.2.3, v2.2.2, v3.0.0'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Deploy release
+    steps:
+      - name: Determine tag to be released
+        run: |
+          TAG=${GITHUB_REF:10}
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            TAG="${{ github.event.inputs.tag }}" 
+          fi
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+          echo "VERSION=${TAG:1}" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+        with:
+          ref: "${{ env.TAG }}"
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'temurin'
+          cache: 'maven'
+          server-id: release-repository
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Deploy release
+        run: ./mvnw deploy -Prelease --batch-mode -DskipTests -DretryFailedDeploymentCount=3
+        env:
+          MAVEN_USERNAME: ${{ secrets.SONATYPE_OSS_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.SONATYPE_OSS_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          # We want to create draft release to be able to edit body before actually releasing it.
+          # There is no automatic drafter in this repo.
+          draft: true
+          files: '**/target/hazelcast-wm-${{ env.VERSION }}*.jar'
+          name: "${{ env.VERSION }}"

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -1,0 +1,31 @@
+name: Deploy Snapshot
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Deploy snapshot
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version:  17
+          distribution: 'temurin'
+          cache: 'maven'
+          server-id: snapshot-repository
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+
+      - name: Deploy snapshot
+        run: ./mvnw deploy -Prelease-snapshot --batch-mode --update-snapshots -DskipTests -DretryFailedDeploymentCount=3
+        env:
+          MAVEN_USERNAME: ${{ secrets.SONATYPE_OSS_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.SONATYPE_OSS_PASSWORD }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,43 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      next-version:
+        description: 'Override next development version (e.g. 5.0.0-SNAPSHOT). If not set then the version will be calculated by maven release plugin'
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    name: Prepare release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ssh-key: "${{ secrets.COMMIT_KEY }}"
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version:  17
+          distribution: 'temurin'
+          cache: 'maven'
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Prepare release
+        run: |
+          if [ -n "${{ github.event.inputs.next-version }}" ]; then
+              EXTRA_ARGS=-DdevelopmentVersion=${{ github.event.inputs.next-version }}
+          fi
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<devops@hazelcast.com>"
+          ./mvnw --batch-mode release:prepare -Prelease -Darguments="-DskipTests" $EXTRA_ARGS
+          ./mvnw --batch-mode release:clean
+        env:
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+      - name: Push changes
+        run: |
+          git push
+          git push --tags

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
         <maven.compiler.plugin.version>3.5.1</maven.compiler.plugin.version>
         <maven.jar.plugin.version>2.4</maven.jar.plugin.version>
-        <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
+        <maven.source.plugin.version>3.3.1</maven.source.plugin.version>
         <maven.bundle.plugin.version>2.3.7</maven.bundle.plugin.version>
         <maven.animal.sniffer.plugin.version>1.14</maven.animal.sniffer.plugin.version>
         <maven.gpg.plugin.version>1.4</maven.gpg.plugin.version>
@@ -59,6 +59,7 @@
         <maven.spotbugs.plugin.version>4.8.5.0</maven.spotbugs.plugin.version>
         <maven.sonar.plugin.version>3.3.0.603</maven.sonar.plugin.version>
         <maven.jacoco.plugin.version>0.7.9</maven.jacoco.plugin.version>
+        <maven-release-plugin-version>3.0.1</maven-release-plugin-version>
     </properties>
 
     <licenses>
@@ -256,6 +257,20 @@
                     </webAppConfig>
                     <stopPort>9966</stopPort>
                     <stopKey>stop</stopKey>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven-release-plugin-version}</version>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                    <releaseProfiles>release</releaseProfiles>
+                    <scmCommentPrefix>Release - </scmCommentPrefix>
+                    <goals>deploy</goals>
+                    <pushChanges>false</pushChanges>
                 </configuration>
             </plugin>
         </plugins>
@@ -502,16 +517,6 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>${maven.javadoc.plugin.version}</version>
                         <configuration>
-                            <javaApiLinks>
-                                <property>
-                                    <name>api_1.6</name>
-                                    <value>http://download.oracle.com/javase/1.6.0/docs/api/</value>
-                                </property>
-                                <property>
-                                    <name>api_1.7</name>
-                                    <value>http://download.oracle.com/javase/1.7.0/docs/api/</value>
-                                </property>
-                            </javaApiLinks>
                             <maxmemory>1024</maxmemory>
                         </configuration>
                         <executions>
@@ -550,16 +555,6 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>${maven.javadoc.plugin.version}</version>
                         <configuration>
-                            <javaApiLinks>
-                                <property>
-                                    <name>api_1.6</name>
-                                    <value>http://download.oracle.com/javase/1.6.0/docs/api/</value>
-                                </property>
-                                <property>
-                                    <name>api_1.7</name>
-                                    <value>http://download.oracle.com/javase/1.7.0/docs/api/</value>
-                                </property>
-                            </javaApiLinks>
                             <excludePackageNames>
                                 *.impl:*.internal:*.operations:*.proxy:*.util:com.hazelcast.aws.security:
                                 *.handlermigration:*.client.connection.nio:*.client.console:*.buildutils:


### PR DESCRIPTION
Inspired by https://github.com/hazelcast/quarkus-hazelcast-client/tree/master/.github/workflows, this PR adds the workflows needed for semi-automated release workflow:

- A snapshot is created for every push to a master
- After prepare-release is invoked manually with a version, a tag and a commit that updates the version is pushed by the prepare-release.
    -  deploy-release is run afterwards because it runs when a tag is pushed. This workflow will actually deploy the release to remote mvn repository. This workflow can also be run manually. After this runs, it'll create a github release as a draft with the release artifacts (sources jar and actual release jar). Then we'll update the changelog and release it.


Other changes:
- maven-javadoc-plugin's javaApiLinks properties are removed because the link was being redirected to java 22 page, and also java 1.6/1.7 is unsupported now
- Add mvn release plugin used by workflow(s)
- Upgrade mvn source plugin version 
                                