### PR TITLE
Use default server id in setup-jdk

### DIFF
--- a/.github/actions/setup-jdk/action.yml
+++ b/.github/actions/setup-jdk/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
   server-id:
     description: 'server id to deploy'
-    default: ''
+    default: 'snapshot-repository'
     required: false
 
 runs:


### PR DESCRIPTION
Setup jdk seems to be expecting server-id to be available in pom.xml if provided, so let's use a default one if user does not provide