### PR TITLE
Remove JDK 8 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,46 @@
                     <pushChanges>false</pushChanges>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>jdk-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[${jdk.version},)</version>
+                                </requireJavaVersion>
+                                <enforceBytecodeVersion>
+                                    <maxJdkVersion>${jdk.version}</maxJdkVersion>
+                                </enforceBytecodeVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>dependency-convergence</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <dependencyConvergence />
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>extra-enforcer-rules</artifactId>
+                        <version>1.10.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <licenses>
         <license>
             <name>The Hazelcast Community License</name>
-            <url>http://hazelcast.com/hazelcast-community-license</url>
+            <url>https://hazelcast.com/hazelcast-community-license</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -75,8 +75,8 @@
         <connection>scm:git:git://github.com/hazelcast/hazelcast-wm.git</connection>
         <developerConnection>scm:git:git@github.com:hazelcast/hazelcast-wm.git</developerConnection>
         <url>https://github.com/hazelcast/hazelcast/</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
     <developers>
         <developer>
             <id>oztalip</id>
@@ -228,7 +228,6 @@
                                     *
                                 </Import-Package>
                                 <Fragment-Host>com.hazelcast</Fragment-Host>
-                                <!--<Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>-->
                             </instructions>
                         </configuration>
                     </execution>
@@ -299,19 +298,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>jakarta.servlet.jsp</groupId>
-            <artifactId>jakarta.servlet.jsp-api</artifactId>
-            <version>${jsp.api.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <version>${servlet.api.version}</version>
             <scope>provided</scope>
         </dependency>
 
-<!--        Needed to make Tomcat log in tests-->
+        <!-- Needed to make Tomcat log in tests -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,9 @@
         <maven.jacoco.plugin.version>0.7.9</maven.jacoco.plugin.version>
         <maven-release-plugin-version>3.0.1</maven-release-plugin-version>
         <mockito.version>5.12.0</mockito.version>
+
+        <!-- Required for tests with Tomcat and jdk 17 -->
+        <javaModuleArgs>--add-opens java.base/java.io=ALL-UNNAMED</javaModuleArgs>
     </properties>
 
     <licenses>
@@ -152,6 +155,7 @@
                         -Dhazelcast.test.use.network=false
                         -Djava.net.preferIPv4Stack=true
                         -Dhazelcast.logging.type=log4j2
+                        ${javaModuleArgs}
                     </argLine>
                 </configuration>
             </plugin>
@@ -544,15 +548,6 @@
         </profile>
         <profile>
             <id>test-coverage</id>
-            <properties>
-                <argLine>
-                    -Xms128m -Xmx2G
-                    -Dhazelcast.version.check.enabled=false
-                    -Dhazelcast.mancenter.enabled=false
-                    -Dhazelcast.test.use.network=false
-                    -Djava.net.preferIPv4Stack=true
-                </argLine>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -568,6 +563,14 @@
                         <configuration combine.self="override">
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <testFailureIgnore>true</testFailureIgnore>
+                            <argLine>
+                                -Xms128m -Xmx2G
+                                -Dhazelcast.version.check.enabled=false
+                                -Dhazelcast.mancenter.enabled=false
+                                -Dhazelcast.test.use.network=false
+                                -Djava.net.preferIPv4Stack=true
+                                ${javaModuleArgs}
+                            </argLine>
                         </configuration>
                     </plugin>
 
@@ -705,63 +708,5 @@
             </properties>
         </profile>
 
-        <profile>
-            <!-- SUP-420 case. Tomcat 9.0.z and 5.3.z hazelcast. Using jdk 1.8 because tomcat supports 1.8.
-             Therefore, we have to exclude jetty tests from compiling/running and jetty classes from classpath
-              because they require jdk 11. -->
-            <id>tomcat-jdk8</id>
-            <properties>
-                <hazelcast.version>5.3.7</hazelcast.version>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>${maven.compiler.plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <id>default-testCompile</id>
-                                <phase>test-compile</phase>
-                                <goals>
-                                    <goal>testCompile</goal>
-                                </goals>
-                                <configuration>
-                                    <testExcludes>
-                                        <exclude>
-                                            com/hazelcast/wm/test/jetty/**/*.java
-                                        </exclude>
-                                    </testExcludes>
-                                </configuration>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <source>${jdk.version}</source>
-                            <target>${jdk.version}</target>
-                        </configuration>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${maven.surefire.plugin.version}</version>
-                        <configuration combine.self="override">
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                            <runOrder>failedfirst</runOrder>
-                            <excludes>
-                                <exclude>
-                                    com.hazelcast.wm.test.jetty.*
-                                </exclude>
-                            </excludes>
-                            <classpathDependencyExcludes>
-                                <classpathDependencyExclude>
-                                    org.eclipse.jetty:apache-jsp
-                                </classpathDependencyExclude>
-                            </classpathDependencyExcludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/src/main/java/com/hazelcast/web/ClusteredSessionService.java
+++ b/src/main/java/com/hazelcast/web/ClusteredSessionService.java
@@ -43,7 +43,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-
+import java.util.logging.Level;
 
 
 /**
@@ -100,7 +100,7 @@ public class ClusteredSessionService {
                 ensureInstance();
             } catch (Exception e) {
                 if (LOGGER.isFinestEnabled()) {
-                    LOGGER.finest("Cannot connect hazelcast server", e);
+                    LOGGER.log(Level.FINEST, "Cannot connect hazelcast server", e);
                 }
             }
         }, 2 * CLUSTER_CHECK_INTERVAL, CLUSTER_CHECK_INTERVAL, TimeUnit.SECONDS);
@@ -119,7 +119,7 @@ public class ClusteredSessionService {
                     setFailedConnection(true);
                     LOGGER.warning("Cannot connect to Hazelcast server: " + e.getMessage());
                     if (LOGGER.isFinestEnabled()) {
-                        LOGGER.finest("Cannot connect hazelcast server", e);
+                        LOGGER.log(Level.FINEST, "Cannot connect hazelcast server", e);
                     }
                 }
             }
@@ -127,13 +127,13 @@ public class ClusteredSessionService {
     }
 
     private void reconnectHZInstance() throws ServletException {
-        LOGGER.info("Retrying the connection!!");
+        LOGGER.log(Level.INFO, "Retrying the connection!");
         lastConnectionTry = System.currentTimeMillis();
         hazelcastInstance = HazelcastInstanceLoader.loadInstance(this, filterConfig);
         clusterMap = hazelcastInstance.getMap(filterConfig.getMapName());
         sss = (SerializationServiceSupport) hazelcastInstance;
         setFailedConnection(false);
-        LOGGER.info("Successfully Connected!");
+        LOGGER.log(Level.INFO, "Successfully Connected!");
     }
 
     private void clearOrphanSessionQueue() {
@@ -159,7 +159,7 @@ public class ClusteredSessionService {
         try {
             return clusterMap.executeOnKey(sessionId, processor);
         } catch (Exception e) {
-            LOGGER.finest("Cannot connect hazelcast server", e);
+            LOGGER.log(Level.FINEST, "Cannot connect hazelcast server", e);
             throw e;
         }
     }

--- a/src/main/java/com/hazelcast/web/HazelcastHttpSession.java
+++ b/src/main/java/com/hazelcast/web/HazelcastHttpSession.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 
 /**
  * HazelcastHttpSession is HttpSession implementation based on Hazelcast Imap.
@@ -117,7 +118,7 @@ public class HazelcastHttpSession implements HttpSession {
                 localCache.put(name, cacheEntry);
             } catch (Exception e) {
                 if (LOGGER.isFinestEnabled()) {
-                    LOGGER.finest("session could not be load so you might be dealing with stale data", e);
+                    LOGGER.log(Level.FINEST, "session could not be load so you might be dealing with stale data", e);
                 }
                 if (cacheEntry == null) {
                     return null;
@@ -265,7 +266,7 @@ public class HazelcastHttpSession implements HttpSession {
                     localCache.put(attributeKey, cacheEntry);
                 }
                 if (LOGGER.isFinestEnabled()) {
-                    LOGGER.finest("Storing " + attributeKey + " on session " + id);
+                    LOGGER.log("Storing " + attributeKey + " on session " + id);
                 }
                 cacheEntry.setValue(entry.getValue());
                 cacheEntry.setDirty(false);

--- a/src/main/java/com/hazelcast/web/HazelcastHttpSession.java
+++ b/src/main/java/com/hazelcast/web/HazelcastHttpSession.java
@@ -266,7 +266,7 @@ public class HazelcastHttpSession implements HttpSession {
                     localCache.put(attributeKey, cacheEntry);
                 }
                 if (LOGGER.isFinestEnabled()) {
-                    LOGGER.log("Storing " + attributeKey + " on session " + id);
+                    LOGGER.log(Level.FINEST, "Storing " + attributeKey + " on session " + id);
                 }
                 cacheEntry.setValue(entry.getValue());
                 cacheEntry.setDirty(false);

--- a/src/main/java/com/hazelcast/web/WebFilter.java
+++ b/src/main/java/com/hazelcast/web/WebFilter.java
@@ -215,7 +215,7 @@ public class WebFilter implements Filter {
         String oldHazelcastSessionId = originalSessions.put(originalSessionId, hazelcastSession.getId());
         if (LOGGER.isFinestEnabled()) {
             if (oldHazelcastSessionId != null) {
-                LOGGER.log(Level.FINEST,"!!! Overwrote an existing hazelcastSessionId " + oldHazelcastSessionId);
+                LOGGER.log(Level.FINEST, "Overwrote an existing hazelcastSessionId " + oldHazelcastSessionId);
             }
             LOGGER.log(Level.FINEST, "Created new session with id: " + hazelcastSession.getId());
             LOGGER.log(Level.FINEST, sessions.size() + " is sessions.size and originalSessions.size: " + originalSessions.size());
@@ -306,7 +306,7 @@ public class WebFilter implements Filter {
         if (session != null && session.isValid()) {
             if (config.isDeferredWrite()) {
                 if (LOGGER.isFinestEnabled()) {
-                    LOGGER.finest("UPDATING SESSION " + session.getId());
+                    LOGGER.log(Level.FINEST, "Updating session " + session.getId());
                 }
                 session.sessionDeferredWrite();
             }
@@ -418,7 +418,7 @@ public class WebFilter implements Filter {
             // following chunk is executed _only_ when session is invalidated and getSession is called on the request
             String invalidatedOriginalSessionId = null;
             if (hazelcastSession != null && !hazelcastSession.isValid()) {
-                LOGGER.finest("Session is invalid!");
+                LOGGER.log(Level.FINEST, "Session is invalid!");
                 destroySession(hazelcastSession, true);
                 invalidatedOriginalSessionId = hazelcastSession.invalidatedOriginalSessionId;
                 hazelcastSession = null;

--- a/src/main/java/com/hazelcast/web/WebFilter.java
+++ b/src/main/java/com/hazelcast/web/WebFilter.java
@@ -160,7 +160,7 @@ public class WebFilter implements Filter {
         clusteredSessionService = new ClusteredSessionService(this.config);
 
         if (LOGGER.isLoggable(Level.FINEST)) {
-            LOGGER.finest(this.config.toString());
+            LOGGER.log(Level.FINEST, this.config.toString());
         }
     }
 
@@ -180,11 +180,11 @@ public class WebFilter implements Filter {
         if (!create && !sessionExistsInTheCluster) {
             return null;
         }
-        LOGGER.fine("Session %s exists in cluster: %s", existingSessionId, sessionExistsInTheCluster);
+        LOGGER.log(Level.FINE, String.format("Session %s exists in cluster: %s", existingSessionId, sessionExistsInTheCluster));
         String id = sessionExistsInTheCluster ? existingSessionId : generateSessionId();
 
         if (requestWrapper.getOriginalSession(false) != null) {
-            LOGGER.finest("Original session exists!");
+            LOGGER.log(Level.FINEST, "Original session exists!");
         }
         HttpSession originalSession = requestWrapper.getOriginalSession(true);
         HazelcastHttpSession hazelcastSession = createHazelcastHttpSession(id, originalSession);
@@ -215,10 +215,10 @@ public class WebFilter implements Filter {
         String oldHazelcastSessionId = originalSessions.put(originalSessionId, hazelcastSession.getId());
         if (LOGGER.isFinestEnabled()) {
             if (oldHazelcastSessionId != null) {
-                LOGGER.finest("!!! Overwrote an existing hazelcastSessionId " + oldHazelcastSessionId);
+                LOGGER.log(Level.FINEST,"!!! Overwrote an existing hazelcastSessionId " + oldHazelcastSessionId);
             }
-            LOGGER.finest("Created new session with id: " + hazelcastSession.getId());
-            LOGGER.finest(sessions.size() + " is sessions.size and originalSessions.size: " + originalSessions.size());
+            LOGGER.log(Level.FINEST, "Created new session with id: " + hazelcastSession.getId());
+            LOGGER.log(Level.FINEST, sessions.size() + " is sessions.size and originalSessions.size: " + originalSessions.size());
         }
     }
 
@@ -232,7 +232,7 @@ public class WebFilter implements Filter {
      */
     protected void destroySession(HazelcastHttpSession session, boolean invalidate) {
         if (LOGGER.isFinestEnabled()) {
-            LOGGER.finest("Destroying local session: " + session.getId());
+            LOGGER.log(Level.FINEST, "Destroying local session: " + session.getId());
         }
         sessions.remove(session.getId());
         originalSessions.remove(session.getOriginalSession().getId());

--- a/src/main/java/com/hazelcast/web/spring/SpringAwareWebFilter.java
+++ b/src/main/java/com/hazelcast/web/spring/SpringAwareWebFilter.java
@@ -24,6 +24,7 @@ import org.springframework.security.web.session.HttpSessionDestroyedEvent;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 
 import java.util.Properties;
+import java.util.logging.Level;
 
 /**
  * Provides Spring aware Hazelcast based session replication by extending from
@@ -83,7 +84,7 @@ public class SpringAwareWebFilter extends WebFilter {
                      */
                     appContext.publishEvent(new HttpSessionCreatedEvent(session));
 
-                    LOGGER.finest("Published create session event for Spring for session with id "
+                    LOGGER.log(Level.FINEST, "Published create session event for Spring for session with id "
                             + session.getId());
                 }
             }
@@ -111,7 +112,7 @@ public class SpringAwareWebFilter extends WebFilter {
                      */
                     appContext.publishEvent(new HttpSessionDestroyedEvent(session));
 
-                    LOGGER.finest("Published destroy session event for Spring for session with id "
+                    LOGGER.log(Level.FINEST, "Published destroy session event for Spring for session with id "
                             + session.getId());
                 }
             }


### PR DESCRIPTION
Jakarta Servlet requires JDK 11
Jakarta JSP API uses JDK 17 already.

I am now:
- removing old jdk-8 related profile (no longer possible)
- keeping JDK required version at 17