### PR TITLE
Allow Dependabot to run PR Builder

### DIFF
--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -27,7 +27,14 @@ jobs:
 
     steps:
       - name: Detect untrusted community PR
-        if: ${{ needs.check_for_membership.outputs.check-result == 'false' }}
+        if: >-
+          ${{ needs.check_for_membership.outputs.check-result == 'false' &&
+            (
+              github.actor != 'dependabot[bot]' &&
+              github.actor != 'renovate[bot]' &&
+              github.actor != 'mend[bot]'
+            )
+          }}
         run: |
           echo "::error::ERROR: Untrusted external PR. Must be reviewed and executed by Hazelcast" 1>&2;
           exit 1


### PR DESCRIPTION
[Dependabot PR builds fail](https://github.com/hazelcast/hazelcast-wm/pull/206) because Dependabot is not whitelisted.