### PR TITLE
Update PR builder membership test to use `triggering_actor` to make community PR execution easier

### DIFF
--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -16,7 +16,7 @@ jobs:
         id: composite
         uses: hazelcast/hazelcast-tpm/membership@main
         with:
-          member-name: ${{ github.actor }}
+          member-name: ${{ github.triggering_actor }}
           token: ${{ secrets.GH_TOKEN }}
 
   build:


### PR DESCRIPTION
See https://github.com/hazelcast/hazelcast-cpp-client/pull/1442