### PR TITLE
Rescope JUnit dependencies to `test`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -467,12 +467,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <scope>compile</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <scope>compile</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
https://github.com/hazelcast/hazelcast-wm/pull/177 upgraded JUnit `4` -> `5`, but _also_ changed the `scope` from `test` -> `compile`.

This causes the dependent `hazelcast-distribution` artifact to therefore include `junit` as a transitive dependency (although it does not get packaged into the distribution archive).